### PR TITLE
Implement compensation for addresses without a level-1 token

### DIFF
--- a/test.py
+++ b/test.py
@@ -331,6 +331,8 @@ class TestDirectory(object):
 20248,基隆市,中正區,環港街,全
 20243,基隆市,中正區,豐稔街,全
 20249,基隆市,中正區,觀海街,全
+22441,新北市,瑞芳區,中山路,　   2號
+22744,新北市,雙溪區,中山路,全
 36046,苗栗縣,苗栗市,大埔街,全
 81245,高雄市,小港區,豐田街,全
 81245,高雄市,小港區,豐登街,全
@@ -413,6 +415,10 @@ class TestDirectory(object):
         assert self.dir_.find('大埔街') == ''
         assert self.dir_.find('台北市大埔街') == '10068'
         assert self.dir_.find('苗栗縣大埔街') == '36046'
+
+    def test_find_divless(self):
+        assert self.dir_.find('臺北市八德路１段1號') == '10058'
+        assert self.dir_.find('新北市中山路2號') == '22'
 
 if __name__ == '__main__':
     import uniout


### PR DESCRIPTION
When an address lacks a level-1 token, e.g.

```
高雄市 大仁路 6 號
====== ====== ====
 t[0]   t[1]  t[2]

* "t" is the token list of the compiled Address object.
```

the second token in the list (大仁路) will contain a level-2 unit (路 in this case), instead of a level-1 one.

Steps are taken when compensating for an address as follows:
1. When looking up rules from the database.
   
   `t[1]` is checked whether it is really a level-1 token. If it is instead a level-2 one, subsequent tokens are shifted back so that they can be matched with the correct column.
2. When an address is matched with the rule.
   
   `t[1]` is again checked. An additional check on `t[0]` is also performed here because addresses such as "信義路一段2號" are compiled like:
   
      信義路 1 段 2 號
      ====== ==== ====
       t[0]  t[1] t[2]
   
   causing it to match the above criteria. If a level-1 token is truely missing, The level-1 token of the current Rule object is used to fill it in.
3. When an address is matched.
   
   If a given address matches only one rule without ambiguity, we can accept the compensation. Otherwise (two or more rules are possible), the compensation won't work, and we fall back to gradual matching as before.
