### PR TITLE
Implement compensation for addresses without a level-1 token

### DIFF
--- a/test.py
+++ b/test.py
@@ -331,6 +331,8 @@ class TestDirectory(object):
 20248,基隆市,中正區,環港街,全
 20243,基隆市,中正區,豐稔街,全
 20249,基隆市,中正區,觀海街,全
+22441,新北市,瑞芳區,中山路,　   2號
+22744,新北市,雙溪區,中山路,全
 36046,苗栗縣,苗栗市,大埔街,全
 81245,高雄市,小港區,豐田街,全
 81245,高雄市,小港區,豐登街,全
@@ -413,6 +415,10 @@ class TestDirectory(object):
         assert self.dir_.find('大埔街') == ''
         assert self.dir_.find('台北市大埔街') == '10068'
         assert self.dir_.find('苗栗縣大埔街') == '36046'
+
+    def test_find_divless(self):
+        assert self.dir_.find('臺北市八德路１段1號') == '10058'
+        assert self.dir_.find('新北市中山路2號') == '22'
 
 if __name__ == '__main__':
     import uniout

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -458,6 +458,7 @@ class Directory(object):
                 else:
                     if match:
                         return match
+
             gzipcode = self.get_gradual_zipcode(addr, i)
             if gzipcode:
                 return gzipcode

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -96,7 +96,7 @@ class Address(object):
         try:
             return self.tokens[val]
         except IndexError:
-            return (u'', u'')
+            return (u'', u'', u'', u'')
 
     def flat(self, sarg=None, *sargs):
         return u''.join(u''.join(token) for token in self.tokens[slice(sarg, *sargs)])

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -25,6 +25,9 @@ class Address(object):
     NAME  = 2
     UNIT  = 3
 
+    UNITS_0 = u'縣市'
+    UNITS_2 = u'里鄰路段街'
+
     TO_REPLACE_RE = re.compile(u'''
         [ 　,，台~-]
         |
@@ -79,8 +82,12 @@ class Address(object):
     def tokenize(addr_str):
         return Address.TOKEN_RE.findall(Address.normalize(addr_str))
 
-    def __init__(self, addr_str):
-        self.tokens = Address.tokenize(addr_str)
+    def __init__(self, str_or_tokens):
+        if isinstance(str_or_tokens, (tuple, list)):
+            tokens = str_or_tokens
+        else:
+            tokens = Address.tokenize(str_or_tokens)
+        self.tokens = tokens
 
     def __len__(self):
         return len(self.tokens)
@@ -163,6 +170,15 @@ class Rule(Address):
         my_last_pos = len(self.tokens)-1
         my_last_pos -= bool(self.rule_tokens) and u'全' not in self.rule_tokens
         my_last_pos -= u'至' in self.rule_tokens
+
+        # Attempts to fill a level-1 token if the input address lacks one.
+
+        addr_tokens = [t for t in addr.tokens]
+        if (len(addr_tokens) > 1
+                and addr_tokens[0][Address.UNIT] in Address.UNITS_0
+                and addr_tokens[1][Address.UNIT] in Address.UNITS_2):
+            addr_tokens.insert(1, self.tokens[1])
+            addr = Address(addr_tokens)
 
         # tokens must be matched exactly
 
@@ -358,12 +374,19 @@ class Directory(object):
                 row[0].decode('utf-8'),
             )
 
-    def get_rule_str_zipcode_pairs(self, addr):
+    def get_rule_str_zipcode_pairs(self, addr, *sargs):
 
         where_params = ([], [])
-        for level, token in enumerate(addr.tokens[:4]):
+
+        level = 0
+        tokens = addr.tokens[slice(*sargs)]
+        while level < min(4, len(tokens)):
+            token = tokens[level]
+            if level == 1 and token[Address.UNIT] in Address.UNITS_2:
+                level += 1
             where_params[0].append('addr_%d = ?' % level)
             where_params[1].append(''.join(token))
+            level += 1
 
         query = '''
             select rule_str, zipcode
@@ -375,13 +398,13 @@ class Directory(object):
 
         return self.cur.fetchall()
 
-    def get_gradual_zipcode(self, addr_str):
+    def get_gradual_zipcode(self, addr, *sargs):
 
         self.cur.execute('''
             select zipcode
             from   gradual
             where  addr_str = ?;
-        ''', (addr_str,))
+        ''', (addr.flat(*sargs),))
 
         row = self.cur.fetchone()
         return row and row[0] or None
@@ -401,9 +424,7 @@ class Directory(object):
 
         for i in range(start_len, 0, -1):
 
-            addr_str = addr.flat(i)
-
-            rzpairs = self.get_rule_str_zipcode_pairs(addr_str)
+            rzpairs = self.get_rule_str_zipcode_pairs(addr, i)
 
             # for handling insignificant tokens and redundant unit
             if (
@@ -428,11 +449,16 @@ class Directory(object):
                     rzpairs = self.get_rule_str_zipcode_pairs(addr.flat(3))
 
             if rzpairs:
+                match = None
                 for rule_str, zipcode in rzpairs:
                     if Rule(rule_str).match(addr):
-                        return zipcode
-
-            gzipcode = self.get_gradual_zipcode(addr_str)
+                        if match:   # Multiple matches found. Failed.
+                            break
+                        match = zipcode
+                else:
+                    if match:
+                        return match
+            gzipcode = self.get_gradual_zipcode(addr, i)
             if gzipcode:
                 return gzipcode
 

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -360,15 +360,18 @@ class Directory(object):
 
     def get_rule_str_zipcode_pairs(self, addr):
 
-        tokens = addr[:4]
-        self.cur.execute('''
+        where_params = ([], [])
+        for level, token in enumerate(addr.tokens[:4]):
+            where_params[0].append('addr_%d = ?' % level)
+            where_params[1].append(''.join(token))
+
+        query = '''
             select rule_str, zipcode
             from   precise
-            where  addr_0 = ?
-                   and addr_1 = ?
-                   and addr_2 = ?
-                   and addr_3 = ?;
-        ''', [''.join(t) for t in tokens] + [''] * (4 - len(tokens)))
+            where  %s;
+        ''' % (' and '.join(where_params[0]))
+
+        self.cur.execute(query, where_params[1])
 
         return self.cur.fetchall()
 

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -85,6 +85,12 @@ class Address(object):
     def __len__(self):
         return len(self.tokens)
 
+    def __getitem__(self, val):
+        try:
+            return self.tokens[val]
+        except IndexError:
+            return (u'', u'')
+
     def flat(self, sarg=None, *sargs):
         return u''.join(u''.join(token) for token in self.tokens[slice(sarg, *sargs)])
 
@@ -226,12 +232,20 @@ class Directory(object):
 
     def create_tables(self):
 
+        # Division levels for an address:
+        # 0. 直轄市, 縣
+        # 1. 區, 縣轄市, 鄉鎮 etc.
+        # 2. 路, 街 (含段)
+        # 3. 其他部分
         self.cur.execute('''
             create table precise (
-                addr_str text,
+                addr_0 text,
+                addr_1 text,
+                addr_2 text,
+                addr_3 text,
                 rule_str text,
                 zipcode  text,
-                primary key (addr_str, rule_str)
+                primary key (addr_0, addr_1, addr_2, addr_3, rule_str)
             );
         ''')
 
@@ -242,10 +256,15 @@ class Directory(object):
             );
         ''')
 
-    def put_precise(self, addr_str, rule_str, zipcode):
+    def put_precise(self, addr, rule_str, zipcode):
 
-        self.cur.execute('insert or ignore into precise values (?, ?, ?);', (
-            addr_str,
+        self.cur.execute('''
+            insert or ignore into precise values (?, ?, ?, ?, ?, ?);
+        ''', (
+            ''.join(addr[0]),
+            ''.join(addr[1]),
+            ''.join(addr[2]),
+            ''.join(addr[3]),
             rule_str,
             zipcode
         ))
@@ -280,7 +299,7 @@ class Directory(object):
         # (a, b, c)
 
         self.put_precise(
-            addr.flat(),
+            addr,
             head_addr_str+tail_rule_str,
             zipcode
         )
@@ -339,13 +358,17 @@ class Directory(object):
                 row[0].decode('utf-8'),
             )
 
-    def get_rule_str_zipcode_pairs(self, addr_str):
+    def get_rule_str_zipcode_pairs(self, addr):
 
+        tokens = addr[:4]
         self.cur.execute('''
             select rule_str, zipcode
             from   precise
-            where  addr_str = ?;
-        ''', (addr_str,))
+            where  addr_0 = ?
+                   and addr_1 = ?
+                   and addr_2 = ?
+                   and addr_3 = ?;
+        ''', [''.join(t) for t in tokens] + [''] * (4 - len(tokens)))
 
         return self.cur.fetchall()
 


### PR DESCRIPTION
Take 2 of #2, rebased to the current HEAD (`dev` branch).

One thing I forgot to mention in the previous PR: This implementation requires a change of database schema. The current installation, if I understand correctly, rebuilds the database every time there's an upgrade, so this shouldn't be a big problem. Please correct me if I'm wrong.

Following is the original PR message:

---

When an address lacks a level-1 token, e.g.

```
高雄市 大仁路 6 號
====== ====== ====
 t[0]   t[1]  t[2]

* "t" is the token list of the compiled Address object.
```

the second token in the list (大仁路) will contain a level-2 unit (路 in this case), instead of a level-1 one.

Steps are taken when compensating for an address as follows:
1. When looking up rules from the database.
   
   `t[1]` is checked whether it is really a level-1 token. If it is instead a level-2 one, subsequent tokens are shifted back so that they can be matched with the correct column.
2. When an address is matched with the rule.
   
   `t[1]` is again checked. An additional check on `t[0]` is also performed here because addresses such as "信義路一段2號" are compiled like:

```
       信義路 1 段 2 號
       ====== ==== ====
        t[0]  t[1] t[2]
```

   causing it to match the above criteria. If a level-1 token is truely missing, The level-1 token of the current Rule object is used to fill it in.
1. When an address is matched.
   
   If a given address matches only one rule without ambiguity, we can accept the compensation. Otherwise (two or more rules are possible), the compensation won't work, and we fall back to gradual matching as before.
