### PR TITLE
Python 3 support

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from time import time
 from timeit import timeit

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -8,7 +8,7 @@ start = time()
 import zipcodetw
 end = time()
 
-print 'The package took {:.2f} seconds to load.'.format(end-start)
+print('The package took {:.2f} seconds to load.'.format(end-start))
 
 def test_find():
 
@@ -31,4 +31,4 @@ def test_find():
     zipcodetw.find('臺南市中西區府前路1段226號')
 
 n = 1000
-print 'Timeit test_find with n={} took {:.2f} seconds.'.format(n, timeit(test_find, number=n))
+print('Timeit test_find with n={} took {:.2f} seconds.'.format(n, timeit(test_find, number=n)))

--- a/scripts/stat.py
+++ b/scripts/stat.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from collections import defaultdict
 from pprint import pprint

--- a/scripts/stat.py
+++ b/scripts/stat.py
@@ -7,26 +7,26 @@ from pprint import pprint
 def print_report(target_dict, key=None):
 
     len_pairs = len(target_dict)
-    print 'Length of This Dict: {:>6,}'.format(len_pairs)
-    print
+    print('Length of This Dict: {:>6,}'.format(len_pairs))
+    print()
 
     lenio_count_map = defaultdict(int)
-    for k, v in target_dict.iteritems():
+    for k, v in target_dict.items():
         lenio_count_map[(len(k), len(v))] += 1
-    total_count = sum(lenio_count_map.itervalues())
+    total_count = sum(lenio_count_map.values())
 
-    print 'Count of Each Length of Input, Output Pair:'
-    print
+    print('Count of Each Length of Input, Output Pair:')
+    print()
 
     cum_pct = .0
-    for lenio, count in sorted(lenio_count_map.iteritems(), key=key):
+    for lenio, count in sorted(iter(lenio_count_map.items()), key=key):
         pct = 100.*count/total_count
         cum_pct += pct
-        print ' {:7} | {:>7,} | {:>6.2f}% | {:>6.2f}%'.format(lenio, count, pct, cum_pct)
-    print
+        print(' {:7} | {:>7,} | {:>6.2f}% | {:>6.2f}%'.format(lenio, count, pct, cum_pct))
+    print()
 
-    print 'Total  : {:>6,}'.format(total_count)
-    print 'Average: {:>9,.2f}'.format(1.*total_count/len(lenio_count_map))
+    print('Total  : {:>6,}'.format(total_count))
+    print('Average: {:>9,.2f}'.format(1.*total_count/len(lenio_count_map)))
 
 if __name__ == '__main__':
 
@@ -36,15 +36,15 @@ if __name__ == '__main__':
     import zipcodetw
     end = time()
 
-    print 'Took {:.2f}s to load.'.format(end-start)
-    print
+    print('Took {:.2f}s to load.'.format(end-start))
+    print()
 
-    print '# Tokens -> Rule Str, Zipcode Pairs (smaller is better)'
-    print
+    print('# Tokens -> Rule Str, Zipcode Pairs (smaller is better)')
+    print()
     print_report(zipcodetw._dir.tokens_rzpairs_map)
-    print
-    print
+    print()
+    print()
 
-    print '# Tokens -> Gradual Zipcode (bigger is better)'
-    print
+    print('# Tokens -> Gradual Zipcode (bigger is better)')
+    print()
     print_report(zipcodetw._dir.tokens_gzipcode_map, key=lambda p: (p[0][0], -p[0][1]))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.install import install
 class zipcodetw_install(install):
 
     def run(self):
-        print 'Building ZIP code index ... '
+        print('Building ZIP code index ... ')
         sys.stdout.flush()
         zipcodetw.builder.build()
         install.run(self)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import sys
 import zipcodetw.builder
@@ -40,9 +41,9 @@ setup(
     ],
 
     packages = find_packages(),
+    install_requires = ['six', 'unicodecsv'],
     package_data = {'zipcodetw': ['*.csv', '*.db']},
 
     cmdclass = {'install': zipcodetw_install},
 
 )
-

--- a/test.py
+++ b/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from zipcodetw.util import Address
 

--- a/test.py
+++ b/test.py
@@ -5,63 +5,63 @@ from zipcodetw.util import Address
 
 def test_address_init():
 
-    expected_tokens = [(u'', u'', u'臺北', u'市'), (u'', u'', u'大安', u'區'), (u'', u'', u'市府', u'路'), (u'1', u'', u'', u'號')]
-    assert Address(u'臺北市大安區市府路1號').tokens == expected_tokens
+    expected_tokens = [('', '', '臺北', '市'), ('', '', '大安', '區'), ('', '', '市府', '路'), ('1', '', '', '號')]
+    assert Address('臺北市大安區市府路1號').tokens == expected_tokens
     assert Address('臺北市大安區市府路1號').tokens == expected_tokens
 
 def test_address_init_subno():
 
-    expected_tokens = [(u'', u'', u'臺北', u'市'), (u'', u'', u'大安', u'區'), (u'', u'', u'市府', u'路'), (u'1', u'之1', u'', u'號')]
-    assert Address(u'臺北市大安區市府路1之1號').tokens == expected_tokens
+    expected_tokens = [('', '', '臺北', '市'), ('', '', '大安', '區'), ('', '', '市府', '路'), ('1', '之1', '', '號')]
+    assert Address('臺北市大安區市府路1之1號').tokens == expected_tokens
     assert Address('臺北市大安區市府路1之1號').tokens == expected_tokens
 
 def test_address_init_tricky_input():
 
-    assert Address(u'桃園縣中壢市普義').tokens == [(u'', u'', u'桃園', u'縣'), (u'', u'', u'中壢', u'市'), (u'', u'', u'普義', u'')]
-    assert Address(u'桃園縣中壢市普義10號').tokens == [(u'', u'', u'桃園', u'縣'), (u'', u'', u'中壢', u'市'), (u'', u'', u'普義', u''), (u'10', u'', u'', u'號')]
+    assert Address('桃園縣中壢市普義').tokens == [('', '', '桃園', '縣'), ('', '', '中壢', '市'), ('', '', '普義', '')]
+    assert Address('桃園縣中壢市普義10號').tokens == [('', '', '桃園', '縣'), ('', '', '中壢', '市'), ('', '', '普義', ''), ('10', '', '', '號')]
 
-    assert Address(u'臺北市中山區敬業1路').tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中山', u'區'), (u'', u'', u'敬業1', u'路')]
-    assert Address(u'臺北市中山區敬業1路10號').tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中山', u'區'), (u'', u'', u'敬業1', u'路'), (u'10', u'', u'', u'號')]
+    assert Address('臺北市中山區敬業1路').tokens == [('', '', '臺北', '市'), ('', '', '中山', '區'), ('', '', '敬業1', '路')]
+    assert Address('臺北市中山區敬業1路10號').tokens == [('', '', '臺北', '市'), ('', '', '中山', '區'), ('', '', '敬業1', '路'), ('10', '', '', '號')]
 
 def test_address_init_normalization():
 
-    expected_tokens = [(u'', u'', u'臺北', u'市'), (u'', u'', u'大安', u'區'), (u'', u'', u'市府', u'路'), (u'1', u'之1', u'', u'號')]
-    assert Address(u'臺北市大安區市府路1之1號').tokens == expected_tokens
-    assert Address(u'台北市大安區市府路1之1號').tokens == expected_tokens
-    assert Address(u'臺北市大安區市府路１之１號').tokens == expected_tokens
-    assert Address(u'臺北市　大安區　市府路 1 之 1 號').tokens == expected_tokens
-    assert Address(u'臺北市，大安區，市府路 1 之 1 號').tokens == expected_tokens
-    assert Address(u'臺北市, 大安區, 市府路 1 之 1 號').tokens == expected_tokens
-    assert Address(u'臺北市, 大安區, 市府路 1 - 1 號').tokens == expected_tokens
+    expected_tokens = [('', '', '臺北', '市'), ('', '', '大安', '區'), ('', '', '市府', '路'), ('1', '之1', '', '號')]
+    assert Address('臺北市大安區市府路1之1號').tokens == expected_tokens
+    assert Address('台北市大安區市府路1之1號').tokens == expected_tokens
+    assert Address('臺北市大安區市府路１之１號').tokens == expected_tokens
+    assert Address('臺北市　大安區　市府路 1 之 1 號').tokens == expected_tokens
+    assert Address('臺北市，大安區，市府路 1 之 1 號').tokens == expected_tokens
+    assert Address('臺北市, 大安區, 市府路 1 之 1 號').tokens == expected_tokens
+    assert Address('臺北市, 大安區, 市府路 1 - 1 號').tokens == expected_tokens
 
 def test_address_init_normalization_chinese_number():
 
-    assert Address.normalize(u'八德路') == u'八德路'
-    assert Address.normalize(u'三元街') == u'三元街'
+    assert Address.normalize('八德路') == '八德路'
+    assert Address.normalize('三元街') == '三元街'
 
-    assert Address.normalize(u'三號') == u'3號'
-    assert Address.normalize(u'十八號') == u'18號'
-    assert Address.normalize(u'三十八號') == u'38號'
+    assert Address.normalize('三號') == '3號'
+    assert Address.normalize('十八號') == '18號'
+    assert Address.normalize('三十八號') == '38號'
 
-    assert Address.normalize(u'三段') == u'3段'
-    assert Address.normalize(u'十八路') == u'18路'
-    assert Address.normalize(u'三十八街') == u'38街'
+    assert Address.normalize('三段') == '3段'
+    assert Address.normalize('十八路') == '18路'
+    assert Address.normalize('三十八街') == '38街'
 
-    assert Address.normalize(u'信義路一段') == u'信義路1段'
-    assert Address.normalize(u'敬業一路') == u'敬業1路'
-    assert Address.normalize(u'愛富三街') == u'愛富3街'
+    assert Address.normalize('信義路一段') == '信義路1段'
+    assert Address.normalize('敬業一路') == '敬業1路'
+    assert Address.normalize('愛富三街') == '愛富3街'
 
 def test_address_flat():
 
     addr = Address('臺北市大安區市府路1之1號')
-    assert addr.flat(1) == addr.flat(-3) == u'臺北市'
-    assert addr.flat(2) == addr.flat(-2) == u'臺北市大安區'
-    assert addr.flat(3) == addr.flat(-1) == u'臺北市大安區市府路'
-    assert addr.flat() == u'臺北市大安區市府路1之1號'
+    assert addr.flat(1) == addr.flat(-3) == '臺北市'
+    assert addr.flat(2) == addr.flat(-2) == '臺北市大安區'
+    assert addr.flat(3) == addr.flat(-1) == '臺北市大安區市府路'
+    assert addr.flat() == '臺北市大安區市府路1之1號'
 
 def test_address_repr():
 
-    repr_str = "Address(u'\u81fa\u5317\u5e02\u5927\u5b89\u5340\u5e02\u5e9c\u8def1\u865f')"
+    repr_str = "Address(u'\\u81fa\\u5317\\u5e02\\u5927\\u5b89\\u5340\\u5e02\\u5e9c\\u8def1\\u865f')"
     assert repr(Address('臺北市大安區市府路1號')) == repr_str
     assert repr(eval(repr_str)) == repr_str
 
@@ -70,66 +70,66 @@ from zipcodetw.util import Rule
 def test_rule_init():
 
     rule = Rule('臺北市,中正區,八德路１段,全')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'八德', u'路'), (u'', u'', u'1', u'段')]
-    assert rule.rule_tokens == set([u'全'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '八德', '路'), ('', '', '1', '段')]
+    assert rule.rule_tokens == set(['全'])
 
     rule = Rule('臺北市,中正區,三元街,單全')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'三元', u'街')]
-    assert rule.rule_tokens == set([u'單', u'全'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '三元', '街')]
+    assert rule.rule_tokens == set(['單', '全'])
 
     rule = Rule('臺北市,中正區,三元街,雙  48號以下')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'三元', u'街'), (u'48', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'雙', u'以下'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '三元', '街'), ('48', '', '', '號')]
+    assert rule.rule_tokens == set(['雙', '以下'])
 
     rule = Rule('臺北市,中正區,大埔街,單  15號以上')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'大埔', u'街'), (u'15', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'單', u'以上'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '大埔', '街'), ('15', '', '', '號')]
+    assert rule.rule_tokens == set(['單', '以上'])
 
     rule = Rule('臺北市,中正區,中華路１段,單  25之   3號以下')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'中華', u'路'), (u'', u'', u'1', u'段'), (u'25', u'之3', u'', u'號')]
-    assert rule.rule_tokens == set([u'單', u'以下'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '中華', '路'), ('', '', '1', '段'), ('25', '之3', '', '號')]
+    assert rule.rule_tokens == set(['單', '以下'])
 
     rule = Rule('臺北市,中正區,中華路１段,單  27號至  47號')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'中華', u'路'), (u'', u'', u'1', u'段'), (u'27', u'', u'', u'號'), (u'47', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'單', u'至'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '中華', '路'), ('', '', '1', '段'), ('27', '', '', '號'), ('47', '', '', '號')]
+    assert rule.rule_tokens == set(['單', '至'])
 
     rule = Rule('臺北市,中正區,仁愛路１段,連   2之   4號以上')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'仁愛', u'路'), (u'', u'', u'1', u'段'), (u'2', u'之4', u'', u'號')]
-    assert rule.rule_tokens == set([ u'以上'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '仁愛', '路'), ('', '', '1', '段'), ('2', '之4', '', '號')]
+    assert rule.rule_tokens == set([ '以上'])
 
     rule = Rule('臺北市,中正區,杭州南路１段,　  14號含附號')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'中正', u'區'), (u'', u'', u'杭州南', u'路'), (u'', u'', u'1', u'段'), (u'14', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'含附號'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '中正', '區'), ('', '', '杭州南', '路'), ('', '', '1', '段'), ('14', '', '', '號')]
+    assert rule.rule_tokens == set(['含附號'])
 
     rule = Rule('臺北市,大同區,哈密街,　  47附號全')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'大同', u'區'), (u'', u'', u'哈密', u'街'), (u'47', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'附號全'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '大同', '區'), ('', '', '哈密', '街'), ('47', '', '', '號')]
+    assert rule.rule_tokens == set(['附號全'])
 
     rule = Rule('臺北市,大同區,哈密街,雙  68巷至  70號含附號全')
-    assert rule.tokens == [(u'', u'', u'臺北', u'市'), (u'', u'', u'大同', u'區'), (u'', u'', u'哈密', u'街'), (u'68', u'', u'', u'巷'), (u'70', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'雙', u'至', u'含附號全'])
+    assert rule.tokens == [('', '', '臺北', '市'), ('', '', '大同', '區'), ('', '', '哈密', '街'), ('68', '', '', '巷'), ('70', '', '', '號')]
+    assert rule.rule_tokens == set(['雙', '至', '含附號全'])
 
     rule = Rule('桃園縣,中壢市,普義,連  49號含附號以下')
-    assert rule.tokens == [(u'', u'', u'桃園', u'縣'), (u'', u'', u'中壢', u'市'), (u'', u'', u'普義', u''), (u'49', u'', u'', u'號')]
-    assert rule.rule_tokens == set([u'含附號以下'])
+    assert rule.tokens == [('', '', '桃園', '縣'), ('', '', '中壢', '市'), ('', '', '普義', ''), ('49', '', '', '號')]
+    assert rule.rule_tokens == set(['含附號以下'])
 
     rule = Rule('臺中市,西屯區,西屯路３段西平南巷,　   1之   3號及以上附號')
-    assert rule.tokens == [(u'', u'', u'臺中', u'市'), (u'', u'', u'西屯', u'區'), (u'', u'', u'西屯', u'路'), (u'', u'', u'3', u'段'), (u'', u'', u'西平南', u'巷'), (u'1', u'之3', u'', u'號')]
-    assert rule.rule_tokens == set([u'及以上附號'])
+    assert rule.tokens == [('', '', '臺中', '市'), ('', '', '西屯', '區'), ('', '', '西屯', '路'), ('', '', '3', '段'), ('', '', '西平南', '巷'), ('1', '之3', '', '號')]
+    assert rule.rule_tokens == set(['及以上附號'])
 
 def test_rule_init_tricky_input():
 
     rule = Rule('新北市,中和區,連城路,雙 268之   1號以下')
-    assert rule.tokens == [(u'', u'', u'新北', u'市'), (u'', u'', u'中和', u'區'), (u'', u'', u'連城', u'路'), (u'268', u'之1', u'', u'號')]
-    assert rule.rule_tokens == set([u'雙', u'以下'])
+    assert rule.tokens == [('', '', '新北', '市'), ('', '', '中和', '區'), ('', '', '連城', '路'), ('268', '之1', '', '號')]
+    assert rule.rule_tokens == set(['雙', '以下'])
 
     rule = Rule('新北市,泰山區,全興路,全')
-    assert rule.tokens == [(u'', u'', u'新北', u'市'), (u'', u'', u'泰山', u'區'), (u'', u'', u'全興', u'路')]
-    assert rule.rule_tokens == set([u'全'])
+    assert rule.tokens == [('', '', '新北', '市'), ('', '', '泰山', '區'), ('', '', '全興', '路')]
+    assert rule.rule_tokens == set(['全'])
 
 def test_rule_repr():
 
-    repr_str = "Rule(u'\u81fa\u5317\u5e02\u5927\u5b89\u5340\u5e02\u5e9c\u8def1\u865f\u4ee5\u4e0a')"
+    repr_str = "Rule(u'\\u81fa\\u5317\\u5e02\\u5927\\u5b89\\u5340\\u5e02\\u5e9c\\u8def1\\u865f\\u4ee5\\u4e0a')"
     assert repr(Rule('臺北市大安區市府路1號以上')) == repr_str
     assert repr(eval(repr_str)) == repr_str
 
@@ -137,47 +137,47 @@ def test_rule_match():
 
     # standard address w/ standard rules
 
-    addr = Address(u'臺北市大安區市府路5號')
+    addr = Address('臺北市大安區市府路5號')
 
     # 全單雙
-    assert     Rule(u'臺北市大安區市府路全').match(addr)
-    assert     Rule(u'臺北市大安區市府路單全').match(addr)
-    assert not Rule(u'臺北市大安區市府路雙全').match(addr)
+    assert     Rule('臺北市大安區市府路全').match(addr)
+    assert     Rule('臺北市大安區市府路單全').match(addr)
+    assert not Rule('臺北市大安區市府路雙全').match(addr)
 
     # 以上 & 以下
-    assert not Rule(u'臺北市大安區市府路6號以上').match(addr)
-    assert     Rule(u'臺北市大安區市府路6號以下').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號以上').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號以下').match(addr)
-    assert     Rule(u'臺北市大安區市府路4號以上').match(addr)
-    assert not Rule(u'臺北市大安區市府路4號以下').match(addr)
+    assert not Rule('臺北市大安區市府路6號以上').match(addr)
+    assert     Rule('臺北市大安區市府路6號以下').match(addr)
+    assert     Rule('臺北市大安區市府路5號以上').match(addr)
+    assert     Rule('臺北市大安區市府路5號').match(addr)
+    assert     Rule('臺北市大安區市府路5號以下').match(addr)
+    assert     Rule('臺北市大安區市府路4號以上').match(addr)
+    assert not Rule('臺北市大安區市府路4號以下').match(addr)
 
     # 至
-    assert not Rule(u'臺北市大安區市府路1號至4號').match(addr)
-    assert     Rule(u'臺北市大安區市府路1號至5號').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號至9號').match(addr)
-    assert not Rule(u'臺北市大安區市府路6號至9號').match(addr)
+    assert not Rule('臺北市大安區市府路1號至4號').match(addr)
+    assert     Rule('臺北市大安區市府路1號至5號').match(addr)
+    assert     Rule('臺北市大安區市府路5號至9號').match(addr)
+    assert not Rule('臺北市大安區市府路6號至9號').match(addr)
 
     # 附號
-    assert not Rule(u'臺北市大安區市府路6號及以上附號').match(addr)
-    assert     Rule(u'臺北市大安區市府路6號含附號以下').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號及以上附號').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號含附號').match(addr)
-    assert not Rule(u'臺北市大安區市府路5附號全').match(addr)
-    assert     Rule(u'臺北市大安區市府路5號含附號以下').match(addr)
-    assert     Rule(u'臺北市大安區市府路4號及以上附號').match(addr)
-    assert not Rule(u'臺北市大安區市府路4號含附號以下').match(addr)
+    assert not Rule('臺北市大安區市府路6號及以上附號').match(addr)
+    assert     Rule('臺北市大安區市府路6號含附號以下').match(addr)
+    assert     Rule('臺北市大安區市府路5號及以上附號').match(addr)
+    assert     Rule('臺北市大安區市府路5號含附號').match(addr)
+    assert not Rule('臺北市大安區市府路5附號全').match(addr)
+    assert     Rule('臺北市大安區市府路5號含附號以下').match(addr)
+    assert     Rule('臺北市大安區市府路4號及以上附號').match(addr)
+    assert not Rule('臺北市大安區市府路4號含附號以下').match(addr)
 
     # 單雙 x 以上, 至, 以下
-    assert     Rule(u'臺北市大安區市府路單5號以上').match(addr)
-    assert not Rule(u'臺北市大安區市府路雙5號以上').match(addr)
-    assert     Rule(u'臺北市大安區市府路單1號至5號').match(addr)
-    assert not Rule(u'臺北市大安區市府路雙1號至5號').match(addr)
-    assert     Rule(u'臺北市大安區市府路單5號至9號').match(addr)
-    assert not Rule(u'臺北市大安區市府路雙5號至9號').match(addr)
-    assert     Rule(u'臺北市大安區市府路單5號以下').match(addr)
-    assert not Rule(u'臺北市大安區市府路雙5號以下').match(addr)
+    assert     Rule('臺北市大安區市府路單5號以上').match(addr)
+    assert not Rule('臺北市大安區市府路雙5號以上').match(addr)
+    assert     Rule('臺北市大安區市府路單1號至5號').match(addr)
+    assert not Rule('臺北市大安區市府路雙1號至5號').match(addr)
+    assert     Rule('臺北市大安區市府路單5號至9號').match(addr)
+    assert not Rule('臺北市大安區市府路雙5號至9號').match(addr)
+    assert     Rule('臺北市大安區市府路單5號以下').match(addr)
+    assert not Rule('臺北市大安區市府路雙5號以下').match(addr)
 
 def test_rule_match_gradual_address():
 
@@ -432,8 +432,8 @@ if __name__ == '__main__':
     #print r.match(a)
 
     r = Rule('新北市,中和區,景平路,雙  64號以下')
-    print r.tokens
+    print(r.tokens)
 
     a = Address('新北市景平路64巷13弄13號')
-    print a.tokens
-    print r.match(a)
+    print(a.tokens)
+    print(r.match(a))

--- a/zipcodetw/builder.py
+++ b/zipcodetw/builder.py
@@ -27,10 +27,10 @@ def build_cmd(chp_csv_path=None, db_path=None):
     -o, --db-path       The output path.
     '''
 
-    print 'Building ZIP code index ...',
+    print('Building ZIP code index ...', end=' ')
     sys.stdout.flush()
     build(chp_csv_path, db_path)
-    print 'Done.'
+    print('Done.')
 
 if __name__ == '__main__':
 

--- a/zipcodetw/builder.py
+++ b/zipcodetw/builder.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 from . import _chp_csv_path, _db_path
@@ -17,7 +19,7 @@ def build(chp_csv_path=None, db_path=None):
     # build the index
 
     dir_ = Directory(db_path)
-    with open(chp_csv_path) as csv_f:
+    with open(chp_csv_path, 'rb') as csv_f:
         dir_.load_chp_csv(csv_f)
 
 def build_cmd(chp_csv_path=None, db_path=None):

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -5,7 +5,7 @@ import re
 
 class Address(object):
 
-    TOKEN_RE = re.compile(u'''
+    TOKEN_RE = re.compile('''
         (?:
             (?P<no>\d+)
             (?P<subno>之\d+)?
@@ -25,7 +25,7 @@ class Address(object):
     NAME  = 2
     UNIT  = 3
 
-    TO_REPLACE_RE = re.compile(u'''
+    TO_REPLACE_RE = re.compile('''
         [ 　,，台~-]
         |
         [０-９]
@@ -38,14 +38,14 @@ class Address(object):
 
     # the strs matched but not in here will be removed
     TO_REPLACE_MAP = {
-        u'-': u'之', u'~': u'之', u'台': u'臺',
-        u'１': u'1', u'２': u'2', u'３': u'3', u'４': u'4', u'５': u'5',
-        u'６': u'6', u'７': u'7', u'８': u'8', u'９': u'9', u'０': u'0',
-        u'一': u'1', u'二': u'2', u'三': u'3', u'四': u'4', u'五': u'5',
-        u'六': u'6', u'七': u'7', u'八': u'8', u'九': u'9',
+        '-': '之', '~': '之', '台': '臺',
+        '１': '1', '２': '2', '３': '3', '４': '4', '５': '5',
+        '６': '6', '７': '7', '８': '8', '９': '9', '０': '0',
+        '一': '1', '二': '2', '三': '3', '四': '4', '五': '5',
+        '六': '6', '七': '7', '八': '8', '九': '9',
     }
 
-    CHINESE_NUMERALS_SET = set(u'一二三四五六七八九十')
+    CHINESE_NUMERALS_SET = set('一二三四五六七八九十')
 
     @staticmethod
     def normalize(s):
@@ -64,11 +64,11 @@ class Address(object):
             if found[0] in Address.CHINESE_NUMERALS_SET:
                 len_found = len(found)
                 if len_found == 2:
-                    return u'1'+Address.TO_REPLACE_MAP[found[1]]
+                    return '1'+Address.TO_REPLACE_MAP[found[1]]
                 if len_found == 3:
                     return Address.TO_REPLACE_MAP[found[0]]+Address.TO_REPLACE_MAP[found[2]]
 
-            return u''
+            return ''
 
         s = Address.TO_REPLACE_RE.sub(replace, s)
 
@@ -85,10 +85,10 @@ class Address(object):
         return len(self.tokens)
 
     def flat(self, sarg=None, *sargs):
-        return u''.join(u''.join(token) for token in self.tokens[slice(sarg, *sargs)])
+        return ''.join(''.join(token) for token in self.tokens[slice(sarg, *sargs)])
 
     def pick_to_flat(self, *idxs):
-        return u''.join(u''.join(self.tokens[idx]) for idx in idxs)
+        return ''.join(''.join(self.tokens[idx]) for idx in idxs)
 
     def __repr__(self):
         return 'Address(%r)' % self.flat()
@@ -106,7 +106,7 @@ class Address(object):
 
 class Rule(Address):
 
-    RULE_TOKEN_RE = re.compile(u'''
+    RULE_TOKEN_RE = re.compile('''
         及以上附號|含附號以下|含附號全|含附號
         |
         以下|以上
@@ -126,12 +126,12 @@ class Rule(Address):
         def extract(m):
 
             token = m.group()
-            retval = u''
+            retval = ''
 
-            if token == u'連':
-                token = u''
-            elif token == u'附號全':
-                retval = u'號'
+            if token == '連':
+                token = ''
+            elif token == '附號全':
+                retval = '號'
 
             if token:
                 rule_tokens.add(token)
@@ -147,15 +147,15 @@ class Rule(Address):
         Address.__init__(self, addr_str)
 
     def __repr__(self):
-        return 'Rule(%r)' % (self.flat()+u''.join(self.rule_tokens))
+        return 'Rule(%r)' % (self.flat()+''.join(self.rule_tokens))
 
     def match(self, addr):
 
         # except tokens reserved for rule token
 
         my_last_pos = len(self.tokens)-1
-        my_last_pos -= bool(self.rule_tokens) and u'全' not in self.rule_tokens
-        my_last_pos -= u'至' in self.rule_tokens
+        my_last_pos -= bool(self.rule_tokens) and '全' not in self.rule_tokens
+        my_last_pos -= '至' in self.rule_tokens
 
         # tokens must be matched exactly
 
@@ -178,18 +178,18 @@ class Rule(Address):
         my_asst_no_pair = self.parse(-2)
         for rt in self.rule_tokens:
             if (
-                (rt == u'單'         and not his_no_pair[0] & 1 == 1) or
-                (rt == u'雙'         and not his_no_pair[0] & 1 == 0) or
-                (rt == u'以上'       and not his_no_pair >= my_no_pair) or
-                (rt == u'以下'       and not his_no_pair <= my_no_pair) or
-                (rt == u'至'         and not (
+                (rt == '單'         and not his_no_pair[0] & 1 == 1) or
+                (rt == '雙'         and not his_no_pair[0] & 1 == 0) or
+                (rt == '以上'       and not his_no_pair >= my_no_pair) or
+                (rt == '以下'       and not his_no_pair <= my_no_pair) or
+                (rt == '至'         and not (
                     my_asst_no_pair <= his_no_pair <= my_no_pair or
-                    u'含附號全' in self.rule_tokens and his_no_pair[0] == my_no_pair[0]
+                    '含附號全' in self.rule_tokens and his_no_pair[0] == my_no_pair[0]
                 )) or
-                (rt == u'含附號'     and not  his_no_pair[0] == my_no_pair[0]) or
-                (rt == u'附號全'     and not (his_no_pair[0] == my_no_pair[0] and his_no_pair[1] > 0)) or
-                (rt == u'及以上附號' and not  his_no_pair >= my_no_pair) or
-                (rt == u'含附號以下' and not (his_no_pair <= my_no_pair  or his_no_pair[0] == my_no_pair[0]))
+                (rt == '含附號'     and not  his_no_pair[0] == my_no_pair[0]) or
+                (rt == '附號全'     and not (his_no_pair[0] == my_no_pair[0] and his_no_pair[1] > 0)) or
+                (rt == '及以上附號' and not  his_no_pair >= my_no_pair) or
+                (rt == '含附號以下' and not (his_no_pair <= my_no_pair  or his_no_pair[0] == my_no_pair[0]))
             ):
                 return False
 
@@ -383,18 +383,18 @@ class Directory(object):
                 # It only runs once, and must be the first iteration.
                 i == start_len and
                 len_addr_tokens >= 4 and
-                addr.tokens[2][Address.UNIT] in u'村里' and
+                addr.tokens[2][Address.UNIT] in '村里' and
                 not rzpairs
             ):
 
-                if addr.tokens[3][Address.UNIT] == u'鄰':
+                if addr.tokens[3][Address.UNIT] == '鄰':
                     # delete the insignificant token (whose unit is 鄰)
                     del addr.tokens[3]
                     len_addr_tokens -= 1
 
-                if len_addr_tokens >= 4 and addr.tokens[3][Address.UNIT] == u'號':
+                if len_addr_tokens >= 4 and addr.tokens[3][Address.UNIT] == '號':
                     # empty the redundant unit in the token
-                    addr.tokens[2] = (u'', u'', addr.tokens[2][Address.NAME], u'')
+                    addr.tokens[2] = ('', '', addr.tokens[2][Address.NAME], '')
                 else:
                     # delete insignificant token (whose unit is 村 or 里)
                     del addr.tokens[2]
@@ -410,4 +410,4 @@ class Directory(object):
             if gzipcode:
                 return gzipcode
 
-        return u''
+        return ''

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import re
+import six
 
 class Address(object):
 
@@ -50,7 +53,7 @@ class Address(object):
     @staticmethod
     def normalize(s):
 
-        if isinstance(s, str):
+        if isinstance(s, six.binary_type):
             s = s.decode('utf-8')
 
         def replace(m):
@@ -196,7 +199,7 @@ class Rule(Address):
         return True
 
 import sqlite3
-import csv
+import unicodecsv as csv
 from functools import wraps
 
 class Directory(object):
@@ -333,9 +336,9 @@ class Directory(object):
 
         for row in csv.reader(lines_iter):
             self.put(
-                ''.join(row[1:-1]).decode('utf-8'),
-                row[-1].decode('utf-8'),
-                row[0].decode('utf-8'),
+                ''.join(row[1:-1]),
+                row[-1],
+                row[0],
             )
 
     def get_rule_str_zipcode_pairs(self, addr_str):


### PR DESCRIPTION
This PR migrates `zipcodetw` package to support Python 3, primarily by fixing `print`s and CSV processing.

Supporting packages (`six` and `unicodecsv`) introduced to minimize code change.