### PR TITLE
Fix csv parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 six==1.11.0
-unicodecsv==0.14.1

--- a/test.py
+++ b/test.py
@@ -296,7 +296,7 @@ class TestDirectory(object):
 
     def setup(self):
 
-        chp_csv_lines = io.BytesIO('''郵遞區號,縣市名稱,鄉鎮市區,原始路名,投遞範圍
+        s = '''郵遞區號,縣市名稱,鄉鎮市區,原始路名,投遞範圍
 10058,臺北市,中正區,八德路１段,全
 10079,臺北市,中正區,三元街,單全
 10070,臺北市,中正區,三元街,雙  48號以下
@@ -358,7 +358,12 @@ class TestDirectory(object):
 81354,高雄市,左營區,大中二路,雙 700號以上
 81357,高雄市,左營區,大順一路,單  91號至  95號
 81357,高雄市,左營區,大順一路,雙  96號至 568號
-81357,高雄市,左營區,大順一路,單 201號至 389巷'''.encode('utf-8'))
+81357,高雄市,左營區,大順一路,單 201號至 389巷'''
+
+        if six.PY2:
+            chp_csv_lines = io.BytesIO(s.encode('utf-8'))
+        else:
+            chp_csv_lines = io.StringIO(s)
 
         self.dir_ = Directory(':memory:', keep_alive=True)
         self.dir_.load_chp_csv(chp_csv_lines)

--- a/zipcodetw/builder.py
+++ b/zipcodetw/builder.py
@@ -19,7 +19,7 @@ def build(chp_csv_path=None, db_path=None):
     # build the index
 
     dir_ = Directory(db_path)
-    with open(chp_csv_path, 'rb') as csv_f:
+    with open(chp_csv_path, 'r') as csv_f:
         dir_.load_chp_csv(csv_f)
 
 def build_cmd(chp_csv_path=None, db_path=None):

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -199,10 +199,7 @@ class Rule(Address):
         return True
 
 import sqlite3
-try:
-    import unicodecsv as csv
-except ImportError:
-    import csv
+import csv
 from functools import wraps
 
 class Directory(object):
@@ -338,12 +335,7 @@ class Directory(object):
         next(lines_iter)
 
         for row in csv.reader(lines_iter):
-
-            # for py2 py3 compatibility
-            try:
-                row = [val.decode('utf-8') for val in row]
-            except AttributeError:
-                pass
+            row = [ensure_unicode_text(val) for val in row]
 
             self.put(
                 ''.join(row[1:-1]),
@@ -424,3 +416,9 @@ class Directory(object):
                 return gzipcode
 
         return ''
+
+
+def ensure_unicode_text(s):
+    if isinstance(s, six.text_type):
+        return s
+    return s.decode('utf-8')


### PR DESCRIPTION
修正在 Python2 下安裝失敗的問題

```
$ python setup.py install
running install
Building ZIP code index ...
Traceback (most recent call last):
  File "setup.py", line 52, in <module>
    cmdclass = {'install': zipcodetw_install},
  File "/home/ryan/.local/lib/python2.7/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "setup.py", line 14, in run
    zipcodetw.builder.build()
  File "/home/ryan/zipcodetw/zipcodetw/builder.py", line 23, in build
    dir_.load_chp_csv(csv_f)
  File "/home/ryan/zipcodetw/zipcodetw/util.py", line 317, in method_wrapper
    retval = method(self, *args, **kargs)
  File "/home/ryan/zipcodetw/zipcodetw/util.py", line 344, in load_chp_csv
    row = [val.decode('utf-8') for val in row]
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```