### PR TITLE
Fix 'pip install zipcodetw' in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     name = 'zipcodetw',
     version = zipcodetw.__version__,
     description = 'Find Taiwan ZIP code by address fuzzily.',
-    long_description = open('README.rst').read(),
+    long_description = open('README.rst', encoding='UTF-8').read(),
 
     author = 'Mosky',
     url = 'https://github.com/moskytw/zipcodetw',


### PR DESCRIPTION
Add encoding parameter to open() for better windows compatibility.

The latest version of zipcodetw could produce following errors:

Collecting zipcodetw
  Using cached https://files.pythonhosted.org/packages/4d/91/17123d3726cb2619a9c240a47976d55d255e3c6f85c174f74fef462e0705/zipcodetw-0.6.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "***\pip-install-w63soerl\zipcodetw\setup.py", line 25, in <module>
        long_description = open('README.rst').read(),
    UnicodeDecodeError: 'cp950' codec can't decode byte 0xe8 in position 678: illegal multibyte sequence
Command "python setup.py egg_info" failed with error code 1 in ***\pip-install-w63soerl\zipcodetw\