### PR TITLE
Fix build index problem in reinstallation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ class zipcodetw_install(install):
     def run(self):
         print('Building ZIP code index ... ')
         sys.stdout.flush()
-        zipcodetw.builder.build()
+        try:
+            zipcodetw.builder.build()
+        except:
+            print("ZIP code index has been built already.")
         install.run(self)
 
 import zipcodetw


### PR DESCRIPTION
As the error code while doing reinstallation(remove and install again):
```
Traceback (most recent call last):
  File "setup.py", line 52, in <module>
    cmdclass = {'install': zipcodetw_install},
  File "...\lib\site-packages\setuptools-40.8.0-py3.6.egg\setuptools\__init__.py", line 145, in setup
  File "...\appdata\local\programs\python\python36-32\Lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "...\appdata\local\programs\python\python36-32\Lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "...\appdata\local\programs\python\python36-32\Lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 14, in run
    zipcodetw.builder.build()
  File "...\zipcodetw\zipcodetw\builder.py", line 23, in build
    dir_.load_chp_csv(csv_f)
  File "...\zipcodetw\zipcodetw\util.py", line 317, in method_wrapper
    retval = method(self, *args, **kargs)
  File "...\zipcodetw\zipcodetw\util.py", line 335, in load_chp_csv
    self.create_tables()
  File "...\zipcodetw\zipcodetw\util.py", line 241, in create_tables
    ''')
sqlite3.OperationalError: table precise already exists
```
The code in setup.py: zipcodetw.builder.build() will cause the error above which need to [try expect] to let reinstallation can be successfully, thxs ~