### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,24 +3,23 @@
 from __future__ import print_function
 
 import sys
-import zipcodetw.builder
 from setuptools.command.install import install
 
 class zipcodetw_install(install):
 
     def run(self):
+        import zipcodetw.builder
         print('Building ZIP code index ... ')
         sys.stdout.flush()
         zipcodetw.builder.build()
         install.run(self)
 
-import zipcodetw
 from setuptools import setup, find_packages
 
 setup(
 
     name = 'zipcodetw',
-    version = zipcodetw.__version__,
+    version = '0.6.4.1989',
     description = 'Find Taiwan ZIP code by address fuzzily.',
     long_description = open('README.rst', encoding='UTF-8').read(),
 
@@ -47,6 +46,7 @@ setup(
 
     packages = find_packages(),
     install_requires = ['six', 'unicodecsv'],
+    setup_requires = ['six', 'unicodecsv'],
     package_data = {'zipcodetw': ['*.csv', '*.db']},
 
     cmdclass = {'install': zipcodetw_install},


### PR DESCRIPTION
```
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/opt/zipcodetw/setup.py'"'"'; __file__='"'"'/opt/zipcodetw/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', op
en)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-cxdjzwa1
         cwd: /opt/zipcodetw/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/opt/zipcodetw/setup.py", line 6, in <module>
        import zipcodetw.builder
      File "/opt/zipcodetw/zipcodetw/__init__.py", line 7, in <module>
        from .util import Directory
      File "/opt/zipcodetw/zipcodetw/util.py", line 7, in <module>
        import six
    ModuleNotFoundError: No module named 'six'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

```
$ docker run --rm -it -v /home/liyang/zipcodetw:/opt/zipcodetw  python:3.7.7-slim-buster pip install -e /opt/zipcodetw/
```
