### PR TITLE
fix install error in py3 env

### DIFF
--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -344,7 +344,7 @@ class Directory(object):
 
             # for py2 py3 compatibility
             try:
-                row = [val.decode('utf-8') for val in row]
+                row = [six.ensure_text(val) for val in row]
             except AttributeError:
                 pass
 

--- a/zipcodetw/util.py
+++ b/zipcodetw/util.py
@@ -199,9 +199,12 @@ class Rule(Address):
         return True
 
 import sqlite3
-try:
-    import unicodecsv as csv
-except ImportError:
+if six.PY2:
+    try:
+        import unicodecsv as csv
+    except ImportError:
+        import csv
+else:
     import csv
 from functools import wraps
 


### PR DESCRIPTION
1. only import unicodecsv in py2 env
2. use six.ensure_text

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202003292485834